### PR TITLE
Update docs and sketches for NodeMCU replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository documents the wiring and connection strategy for a two-board sys
 
 ## Hardware layout
 
-- **Sender (Arduino Uno + W5500 Ethernet shield)**: Generates Modbus commands. Periodically sends commands via Ethernet to the first ESP32.
+- **Sender (Arduino Uno + W5500 Ethernet shield)**: Generates Modbus commands. Periodically sends commands via Ethernet to the first ESP32. The shield already contains the W5500 chip, so no separate module is required for the Uno.
 - **First ESP32-WROOM-32 + W5500**: Receives Modbus commands from the Arduino over the local network. It relays them over a direct serial connection to the NodeMCU board and can also send data back to the sender.
 - **NodeMCU ESP8266 + W5500**: Communicates with the ESP32 over that serial link. It forwards Modbus frames to the PC as DNP3 and also accepts DNP3 frames from the PC to be returned to the sender.
 - **PC**: Runs the DNP3 master application.
@@ -27,6 +27,8 @@ This repository documents the wiring and connection strategy for a two-board sys
 With this arrangement, the Arduino Uno sender places Modbus frames onto the network, the ESP32 relays them via the serial link, and the NodeMCU converts the frames to DNP3 for the PC. Messages from the PC travel the reverse path back to the sender.
 
 ### W5500 wiring for each board
+
+Note: The Arduino Uno uses a W5500 Ethernet shield with the SPI lines already wired to pins D10--D13. The table below lists these pins for reference.
 
 The W5500 Ethernet modules expose their SPI pins with labels like **S1**, **S2**, **SK**, **S0** and **RST**. Typical headers also include terminals in this order: **SCLK**, **GND**, **SCS**, **INT**, **MOSI**, **MISO**, **GND**, **3.3V**, **5V**, and **RST**. The table below maps the key signals to the board pins used in this project. The same mapping applies to the ESP32 and the NodeMCU.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository documents the wiring and connection strategy for a two-board sys
 
 ## Hardware layout
 
-- **Sender (Arduino Uno + W5500 Ethernet shield)**: Generates Modbus commands. Periodically sends commands via Ethernet to the first ESP32. The shield already contains the W5500 chip, so no separate module is required for the Uno.
+- **Sender (Arduino Uno + W5500 Ethernet shield)**: Generates Modbus commands. Periodically sends commands via Ethernet to the first ESP32. The shield already contains the W5500 chip, so no separate module or extra wiring is required—just stack the shield onto the Uno.
 - **First ESP32-WROOM-32 + W5500**: Receives Modbus commands from the Arduino over the local network. It relays them over a direct serial connection to the NodeMCU board and can also send data back to the sender.
 - **NodeMCU ESP8266 + W5500**: Communicates with the ESP32 over that serial link. It forwards Modbus frames to the PC as DNP3 and also accepts DNP3 frames from the PC to be returned to the sender.
 - **PC**: Runs the DNP3 master application.
@@ -28,7 +28,7 @@ With this arrangement, the Arduino Uno sender places Modbus frames onto the netw
 
 ### W5500 wiring for each board
 
-Note: The Arduino Uno uses a W5500 Ethernet shield with the SPI lines already wired to pins D10--D13. The table below lists these pins for reference.
+Note: The Arduino Uno uses a W5500 Ethernet shield with the SPI lines already wired to pins D10--D13. Simply plug the shield into the Uno—no jumpers are necessary. The table below lists the pins for reference only.
 
 The W5500 Ethernet modules expose their SPI pins with labels like **S1**, **S2**, **SK**, **S0** and **RST**. Typical headers also include terminals in this order: **SCLK**, **GND**, **SCS**, **INT**, **MOSI**, **MISO**, **GND**, **3.3V**, **5V**, and **RST**. The table below maps the key signals to the board pins used in this project. The same mapping applies to the ESP32 and the NodeMCU.
 

--- a/README.md
+++ b/README.md
@@ -1,47 +1,47 @@
 # conversor-2esp
 
-This repository documents the wiring and connection strategy for a dual-ESP system that converts Modbus commands to DNP3 and back again.
+This repository documents the wiring and connection strategy for a two-board system that converts Modbus commands to DNP3 and back again.
 
 ## Hardware layout
 
 - **Sender (Arduino Uno + W5500 Ethernet shield)**: Generates Modbus commands. Periodically sends commands via Ethernet to the first ESP32.
-- **First ESP32-WROOM-32 + W5500**: Receives Modbus commands from the Arduino over the local network. It relays them over a direct serial connection to the second ESP32 and can also send data back to the sender.
-- **Second ESP32-WROOM-32 + W5500**: Communicates with the first ESP32 over that serial link. It forwards Modbus frames to the PC as DNP3 and also accepts DNP3 frames from the PC to be returned to the sender.
+- **First ESP32-WROOM-32 + W5500**: Receives Modbus commands from the Arduino over the local network. It relays them over a direct serial connection to the NodeMCU board and can also send data back to the sender.
+- **NodeMCU ESP8266 + W5500**: Communicates with the ESP32 over that serial link. It forwards Modbus frames to the PC as DNP3 and also accepts DNP3 frames from the PC to be returned to the sender.
 - **PC**: Runs the DNP3 master application.
 - **TP-Link 4‑port modem**: Provides Ethernet connectivity for all nodes.
 
 ### Ethernet port assignment
 
 1. **Port 1 – Sender (Arduino Uno)**
-2. **Port 2 – First ESP32 (Modbus side)**
-3. **Port 3 – Second ESP32 (DNP3 side)**
+2. **Port 2 – ESP32 (Modbus side)**
+3. **Port 3 – NodeMCU ESP8266 (DNP3 side)**
 4. **Port 4 – PC**
 
 ### Wiring steps
 
 1. **Connect each W5500 Ethernet module to the TP-Link modem** using standard Ethernet cables, matching the port assignments above.
-2. **Link the two ESP32 boards** with a direct UART connection. Connect TX2 (GPIO17) on the Modbus ESP32 to RX2 (GPIO16) on the DNP3 ESP32 and vice versa for the return path. This serial link carries the translated command from the first ESP32 to the second.
-3. **Power each ESP device** according to its requirements (typically 3.3&nbsp;V regulated power). Ensure grounds are common if using UART between ESP32 boards.
-4. **From the second ESP32, connect to the PC** via Ethernet over the TP-Link modem. The PC will receive DNP3 messages.
+2. **Link the ESP32 and NodeMCU boards** with a direct UART connection. Connect TX2 (GPIO17) on the Modbus ESP32 to RX (GPIO3) on the NodeMCU and connect TX (GPIO1) on the NodeMCU back to RX2 (GPIO16) on the ESP32. This serial link carries the translated command from the ESP32 to the NodeMCU.
+3. **Power each ESP device** according to its requirements (typically 3.3&nbsp;V regulated power). Ensure grounds are common if using UART between the ESP32 and NodeMCU.
+4. **From the NodeMCU, connect to the PC** via Ethernet over the TP-Link modem. The PC will receive DNP3 messages.
 
-With this arrangement, the Arduino Uno sender places Modbus frames onto the network, the first ESP32 relays them via the serial link, and the second ESP32 converts the frames to DNP3 for the PC. Messages from the PC travel the reverse path back to the sender.
+With this arrangement, the Arduino Uno sender places Modbus frames onto the network, the ESP32 relays them via the serial link, and the NodeMCU converts the frames to DNP3 for the PC. Messages from the PC travel the reverse path back to the sender.
 
 ### W5500 wiring for each board
 
-The W5500 Ethernet modules expose their SPI pins with labels like **S1**, **S2**, **SK**, **S0** and **RST**. Typical headers also include terminals in this order: **SCLK**, **GND**, **SCS**, **INT**, **MOSI**, **MISO**, **GND**, **3.3V**, **5V**, and **RST**. The table below maps the key signals to the board pins used in this project. The same mapping applies to both ESP32 boards.
+The W5500 Ethernet modules expose their SPI pins with labels like **S1**, **S2**, **SK**, **S0** and **RST**. Typical headers also include terminals in this order: **SCLK**, **GND**, **SCS**, **INT**, **MOSI**, **MISO**, **GND**, **3.3V**, **5V**, and **RST**. The table below maps the key signals to the board pins used in this project. The same mapping applies to the ESP32 and the NodeMCU.
 
-| W5500 label | Purpose | Arduino pin | ESP32 pin |
-|-------------|---------|-------------|-----------|
-| S2          | MISO    | D12         | GPIO19    |
-| S1          | MOSI    | D11         | GPIO23    |
-| SK          | SCK     | D13         | GPIO18    |
-| S0          | CS      | D10         | GPIO5     |
-| RST         | Reset   | RESET       | GPIO16    |
-| INT         | Interrupt | unused    | GPIO4     |
+| W5500 label | Purpose | Arduino pin | ESP32 pin | ESP8266 pin |
+|-------------|---------|-------------|-----------|--------------|
+| S2          | MISO    | D12         | GPIO19    | D6 (GPIO12)  |
+| S1          | MOSI    | D11         | GPIO23    | D7 (GPIO13)  |
+| SK          | SCK     | D13         | GPIO18    | D5 (GPIO14)  |
+| S0          | CS      | D10         | GPIO5     | D8 (GPIO15)  |
+| RST         | Reset   | RESET       | GPIO16    | D0 (GPIO16)  |
+| INT         | Interrupt | unused    | GPIO4     | D4 (GPIO2)   |
 
-Power each W5500 module from 3.3&nbsp;V and connect grounds to their respective ESP boards. The Ethernet jack on every W5500 goes to the TP-Link modem using the port assignments above.
+Power each W5500 module from 3.3&nbsp;V and connect grounds to the ESP32 and NodeMCU. The Ethernet jack on every W5500 goes to the TP-Link modem using the port assignments above.
 
-Connect the **RST** terminal so the ESP32 can reset the W5500 during setup. The example sketches pulse GPIO16 low for a short period at startup before bringing it high.
+Connect the **RST** terminal so the ESP32 or NodeMCU can reset the W5500 during setup. The example sketches pulse GPIO16 (or D0 on the NodeMCU) low for a short period at startup before bringing it high.
 #### Dedicated connections
 Each W5500 terminal connects to only one microcontroller pin. Avoid wiring the same W5500 signal to more than one GPIO. The serial link is also one-to-one: connect TX2 on each ESP32 solely to the other board's RX2.
 
@@ -51,30 +51,30 @@ Each W5500 terminal connects to only one microcontroller pin. Avoid wiring the s
 | Device             | Components               | Connections                                        |
 |--------------------|--------------------------|----------------------------------------------------|
 | **Arduino Uno Sender** | Arduino Uno, W5500 shield | Ethernet to port 1 |
-| **Modbus ESP32**   | ESP32 board, W5500       | Ethernet to port 2, UART TX2/RX2 to DNP3 ESP32     |
-| **DNP3 ESP32**     | ESP32 board, W5500       | Ethernet to port 3, UART TX2/RX2 to Modbus ESP32   |
+| **Modbus ESP32**   | ESP32 board, W5500       | Ethernet to port 2, UART TX2/RX2 to NodeMCU |
+| **NodeMCU**        | ESP8266 board, W5500     | Ethernet to port 3, UART TX/RX to Modbus ESP32 |
 | **PC**             | PC running DNP3 master   | Ethernet to port 4                                 |
 
-The two ESP32 boards communicate through a direct 3.3&nbsp;V TTL serial link.
-Connect TX2 (GPIO17) on the Modbus board to RX2 (GPIO16) on the DNP3 board and
-TX2 on the DNP3 board back to RX2 on the Modbus board. Both sides operate at
+The ESP32 and NodeMCU communicate through a direct 3.3&nbsp;V TTL serial link.
+Connect TX2 (GPIO17) on the Modbus board to RX (GPIO3) on the NodeMCU and
+TX (GPIO1) on the NodeMCU back to RX2 (GPIO16) on the ESP32. Both sides operate at
 115200&nbsp;baud using the default 8N1 format.
 
 ### Serial pin reference
 
-The ESP32-WROOM-32 boards expose UART2 as **TX2** (GPIO17) and **RX2** (GPIO16). Wire these terminals together between the two boards as shown below:
+The ESP32-WROOM-32 exposes UART2 as **TX2** (GPIO17) and **RX2** (GPIO16). The NodeMCU uses **TX** (GPIO1) and **RX** (GPIO3). Wire these terminals together between the boards as shown below:
 
 | Board            | Pin label | GPIO | Connection to |
 |------------------|-----------|------|---------------|
-| Modbus ESP32     | TX2       | 17   | DNP3 ESP32 RX2 |
-| Modbus ESP32     | RX2       | 16   | DNP3 ESP32 TX2 |
-| DNP3 ESP32       | TX2       | 17   | Modbus ESP32 RX2 |
-| DNP3 ESP32       | RX2       | 16   | Modbus ESP32 TX2 |
+| Modbus ESP32     | TX2       | 17   | NodeMCU RX (GPIO3) |
+| Modbus ESP32     | RX2       | 16   | NodeMCU TX (GPIO1) |
+| NodeMCU          | TX        | 1    | Modbus ESP32 RX2 |
+| NodeMCU          | RX        | 3    | Modbus ESP32 TX2 |
 
 ### Translation overview
 
 The Modbus ESP32 includes simple routines that wrap Modbus frames inside a
-DNP3-style header before sending them to the DNP3 ESP32. Data received in this
+DNP3-style header before sending them to the NodeMCU. Data received in this
 format is unwrapped back to Modbus before being forwarded to the sender. These
 examples are placeholders—replace them with real protocol handlers for a
 production system.

--- a/src/esp32_modbus_relay.ino
+++ b/src/esp32_modbus_relay.ino
@@ -31,7 +31,7 @@ int dnp3ToModbus(const byte *in, int len, byte *out, int outSize) {
 
 void setup() {
   Serial.begin(115200);
-  Serial2.begin(115200); // Link to second ESP32
+  Serial2.begin(115200); // Link to NodeMCU
   pinMode(W5500_RST, OUTPUT);
   digitalWrite(W5500_RST, LOW);
   delay(50);
@@ -48,7 +48,7 @@ void loop() {
     Serial.println("Modbus ESP32 heartbeat");
     lastBeat = millis();
   }
-  // Data from Arduino Uno to DNP3 ESP32
+  // Data from Arduino Uno to NodeMCU
   EthernetClient client = server.available();
   if (client) {
     byte mbBuf[256];
@@ -69,11 +69,11 @@ void loop() {
 
     byte dnpBuf[260];
     int outLen = modbusToDnp3(mbBuf, mbLen, dnpBuf, sizeof(dnpBuf));
-    Serial.println(" -> sending to DNP3 board");
+    Serial.println(" -> sending to NodeMCU");
     Serial2.write(dnpBuf, outLen);
   }
 
-  // Data from DNP3 ESP32 back to sender
+  // Data from NodeMCU back to sender
   if (Serial2.available()) {
     byte inBuf[256];
     int len = Serial2.readBytes(inBuf, sizeof(inBuf));

--- a/src/esp8266_dnp3_forwarder.ino
+++ b/src/esp8266_dnp3_forwarder.ino
@@ -1,0 +1,67 @@
+#include <SPI.h>
+#include <Ethernet.h>
+
+byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0x03 };
+IPAddress ip(192, 168, 1, 70);
+IPAddress pcIp(192, 168, 1, 80);
+
+const int W5500_RST = 16; // D0 on NodeMCU
+
+EthernetServer server(20000); // Listen for PC
+EthernetClient outClient;
+unsigned long lastBeat = 0;
+
+void setup() {
+  Serial.begin(115200); // Link with Modbus ESP32
+  pinMode(W5500_RST, OUTPUT);
+  digitalWrite(W5500_RST, LOW);
+  delay(50);
+  digitalWrite(W5500_RST, HIGH);
+  delay(50);
+  Ethernet.begin(mac, ip);
+  Serial.print("DNP3 ESP8266 IP: ");
+  Serial.println(Ethernet.localIP());
+  server.begin();
+}
+
+void loop() {
+  if (millis() - lastBeat > 10000) {
+    Serial.println("DNP3 ESP8266 heartbeat");
+    lastBeat = millis();
+  }
+  // From Modbus ESP32 to PC
+  if (Serial.available()) {
+    byte buf[256];
+    int len = Serial.readBytes(buf, sizeof(buf));
+    Serial.print("DNP3 ESP8266 received from Modbus: ");
+    for (int i = 0; i < len; i++) {
+      Serial.print("0x");
+      if (buf[i] < 16) Serial.print("0");
+      Serial.print(buf[i], HEX);
+      Serial.print(" ");
+    }
+    Serial.println(" -> sending to PC");
+    if (outClient.connect(pcIp, 20000)) {
+      outClient.write(buf, len);
+      outClient.stop();
+    }
+  }
+
+  // From PC to Modbus ESP32
+  EthernetClient inc = server.available();
+  if (inc) {
+    Serial.println("DNP3 ESP8266 received from PC:");
+    while (inc.connected()) {
+      if (inc.available()) {
+        byte b = inc.read();
+        Serial.print("0x");
+        if (b < 16) Serial.print("0");
+        Serial.print(b, HEX);
+        Serial.print(" ");
+        Serial.write(b);
+      }
+    }
+    Serial.println();
+    inc.stop();
+  }
+}


### PR DESCRIPTION
### **User description**
## Summary
- document new NodeMCU ESP8266 board in the wiring guide
- add `esp8266_dnp3_forwarder.ino` sketch
- update Modbus relay sketch comments for NodeMCU

## Testing
- `arduino-cli compile src/esp32_modbus_relay.ino` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857750f4a208329ac219fbef84f4d73


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Replace ESP32 with NodeMCU ESP8266 for DNP3 side

- Add new ESP8266 DNP3 forwarder sketch

- Update wiring documentation for NodeMCU integration

- Modify ESP32 sketch comments for NodeMCU compatibility


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation for NodeMCU ESP8266 integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Replace references to "second ESP32" with "NodeMCU ESP8266"<br> <li> Update wiring table to include ESP8266 pin mappings<br> <li> Modify serial connection documentation for ESP32-NodeMCU link<br> <li> Update hardware layout and connection descriptions


</details>


  </td>
  <td><a href="https://github.com/PedroNogacz/conversor-2esp/pull/6/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+31/-31</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>esp32_modbus_relay.ino</strong><dd><code>Update comments for NodeMCU compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/esp32_modbus_relay.ino

<li>Update comments from "second ESP32" to "NodeMCU"<br> <li> Change serial communication references to NodeMCU


</details>


  </td>
  <td><a href="https://github.com/PedroNogacz/conversor-2esp/pull/6/files#diff-a483420a0dce819f3ee74dcbdd2dd1f90ce5ca19b6de219f8cd30133699b1d64">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>esp8266_dnp3_forwarder.ino</strong><dd><code>Add ESP8266 DNP3 forwarder sketch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/esp8266_dnp3_forwarder.ino

<li>Add new Arduino sketch for ESP8266/NodeMCU<br> <li> Implement DNP3 forwarding between Modbus ESP32 and PC<br> <li> Configure W5500 Ethernet with NodeMCU pin mappings<br> <li> Handle bidirectional serial and Ethernet communication


</details>


  </td>
  <td><a href="https://github.com/PedroNogacz/conversor-2esp/pull/6/files#diff-f7b078bfec9af026dec9a03cb03e648f99306ee95b1eb8d177fbe74098b77900">+67/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>