### PR TITLE
Fix command decoding for DNP3 frames

### DIFF
--- a/src/esp32_dnp3_converter.ino
+++ b/src/esp32_dnp3_converter.ino
@@ -294,7 +294,9 @@ void loop() {
     }
     cmdCounter++;
     lastCmdId = cmdCounter;
-    lastCmdFc = buf[1];
+    if (len > 2) {
+      lastCmdFc = buf[2];
+    }
 
     printTimestamp();
     Serial.print("COMMAND C");
@@ -311,7 +313,11 @@ void loop() {
 
     printTimestamp();
     Serial.print("[DNP3] Command Meaning - ");
-    Serial.println(cmdDescription(buf[1]));
+    if (len > 2) {
+      Serial.println(cmdDescription(buf[2]));
+    } else {
+      Serial.println("Unknown");
+    }
 
     printTimestamp();
     Serial.print("[DNP3] Forwarding C");
@@ -350,7 +356,7 @@ void loop() {
 
     cmdCounter++;
     lastCmdId = cmdCounter;
-    if (len > 1) lastCmdFc = buf[1];
+    if (len > 2) lastCmdFc = buf[2];
 
     printTimestamp();
     Serial.print("COMMAND C");
@@ -367,7 +373,11 @@ void loop() {
 
     printTimestamp();
     Serial.print("[DNP3] Command Meaning - ");
-    Serial.println(cmdDescription(buf[1]));
+    if (len > 2) {
+      Serial.println(cmdDescription(buf[2]));
+    } else {
+      Serial.println("Unknown");
+    }
 
     printTimestamp();
     Serial.println("[DNP3] Send ACK to Sender");

--- a/src/esp32_modbus_converter.ino
+++ b/src/esp32_modbus_converter.ino
@@ -382,7 +382,11 @@ void loop() {
     }
     printTimestamp();
     Serial.print("[MODBUS] Command Meaning - ");
-    Serial.println(cmdDescription(inBuf[1]));
+    if (len > 2) {
+      Serial.println(cmdDescription(inBuf[2]));
+    } else {
+      Serial.println("Unknown");
+    }
 
     byte mbBuf[260];
     unsigned long trans2Start = micros();


### PR DESCRIPTION
## Summary
- fix command name parsing in the DNP3 converter when forwarding data
- fix command decoding when Modbus converter receives DNP3 frames

## Testing
- `python -m py_compile python_receiver_pc.py`

------
https://chatgpt.com/codex/tasks/task_e_68605e7e78088329b4ccc2085ce9b297