### PR TITLE
Add unknown message statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,9 @@ converters.  The script listens on **port&nbsp;20000** for DNP3 frames from the
 DNP3 ESP32 and **port&nbsp;1502** for Modbus frames from the Modbus ESP32.  A
 Tkinter window displays each message in separate panes while the console prints
 the same information. The decoded command name is shown so you can verify which
-request was recognized.
+request was recognized. A small graph at the bottom of the window tracks how
+many messages were recognized versus marked as **Unknown** for each protocol so
+you can gauge the overall health of the converters.
 
 #### Requirements
 


### PR DESCRIPTION
## Summary
- track per-protocol stats for recognized and unknown messages
- show progress bars in the GUI with percentages
- update README with description of new graph

## Testing
- `python3 -m py_compile python_receiver_pc.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68632f29d9548329acf6ce371e4e6c86